### PR TITLE
Add dollar signs for shell subcommands

### DIFF
--- a/_posts/2021-02-25-Automount an Encrypted System Volume.adoc
+++ b/_posts/2021-02-25-Automount an Encrypted System Volume.adoc
@@ -141,7 +141,7 @@ Enter any existing passphrase:
 --
 [,sh]
 ----
-echo "backup_crypt UUID="(sudo blkid -o value -s UUID /dev/sdb1)" /etc/cryptsetup-keys.d/backup_crypt.key luks,noauto,nofail,discard" \
+echo "backup_crypt UUID="$(sudo blkid -o value -s UUID /dev/sdb1)" /etc/cryptsetup-keys.d/backup_crypt.key luks,noauto,nofail,discard" \
   | sudo tee -a /etc/crypttab
 backup_crypt UUID=0cbab673-2b14-40c0-a1f2-522bc7ff7e18 /etc/cryptsetup-keys.d/backup_crypt.key luks,noauto,nofail,discard
 ----

--- a/_posts/2021-02-27-Backup Snapper Snapshots With snap-sync.adoc
+++ b/_posts/2021-02-27-Backup Snapper Snapshots With snap-sync.adoc
@@ -140,8 +140,8 @@ Some scripting in the command below determines the UUID of the Btrfs filesystem 
 [,sh]
 ----
 sudo snap-sync -c root \
-  --UUID (sudo blkid -o value -s UUID /dev/mapper/backup_crypt) \
-  --subvolid (sudo btrfs subvolume show /run/media/system/System_Backups \
+  --UUID $(sudo blkid -o value -s UUID /dev/mapper/backup_crypt) \
+  --subvolid $(sudo btrfs subvolume show /run/media/system/System_Backups \
     | awk -F ":[ \t]*" '/Subvolume ID:/ {gsub(//,""); print $2}')
 
 snap-sync version 0.7, Copyright (C) 2016-2021 Wes Barnett


### PR DESCRIPTION
This is allowed in the fish shell now.

Fixes #22.